### PR TITLE
Remove "[DRAFT]" status of the charter

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -1,4 +1,4 @@
-# [DRAFT] Networking Task Force Charter
+Networking Task Force Charter
 
 The mission of the Networking Task Force, part of the W3C Web and Mobile Interest Group, is to evaluate opportunities where better integration with the underlying network can help Web applications achieve a better user experience.
 


### PR DESCRIPTION
It is my understanding the group now considers this charter as {approved, OK, good enough}. As such, the PR removes the "[DRAFT]" tag in the TF's title.
